### PR TITLE
Add /version command with Git info

### DIFF
--- a/LLMs/config.py
+++ b/LLMs/config.py
@@ -57,12 +57,12 @@ MID = 0.7
 HIGH = 1.2
 
 llms = {
-    "smart": ChatOpenAI(model_name="gpt-5"),
-    "mini": ChatOpenAI(model_name="gpt-5-mini"),
-    "gpt4o_high_temp": ChatOpenAI(model_name="gpt-5", temperature=HIGH),
-    "mini_high_temp": ChatOpenAI(model_name="gpt-5-mini", temperature=HIGH),
-    "o3-mini": ChatOpenAI(model_name="o3-mini"),
-    "smartest": ChatOpenAI(model_name="o3"),
+    "smart": ChatOpenAI(model_name="gpt-5", temperature=1),
+    "mini": ChatOpenAI(model_name="gpt-5-mini", temperature=1),
+    "gpt4o_high_temp": ChatOpenAI(model_name="gpt-5", temperature=1),
+    "mini_high_temp": ChatOpenAI(model_name="gpt-5-mini", temperature=1),
+    "o3-mini": ChatOpenAI(model_name="o3-mini", temperature=1),
+    "smartest": ChatOpenAI(model_name="o3", temperature=1),
 }
 
 # Centralized Chain Configuration

--- a/main.py
+++ b/main.py
@@ -71,10 +71,12 @@ def register_handlers(application):
     from features.help.command import help_command
     from features.stopwatch.command import stopwatch_command
     from features.wassup.command import wassup_command
+    from utils.version_command import version_command
     application.add_handler(CommandHandler(["wassup", "hey", "hi"], wassup_command))
     application.add_handler(CommandHandler(["start", "begroeting", "begin"], start_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("stats", stats_command))
+    application.add_handler(CommandHandler("version", version_command))
     application.add_handler(CommandHandler(["wow", "inspiration", "filosofie", "philosophy"], wow_command))
     application.add_handler(CommandHandler("profile", profile_command))
     application.add_handler(CommandHandler(["stopwatch", "timer"], stopwatch_command))

--- a/utils/version.py
+++ b/utils/version.py
@@ -1,0 +1,116 @@
+# utils/version.py
+import subprocess
+import os
+from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+def get_git_info():
+    """
+    Get Git information including commit hash, branch, and commit timestamp.
+    Returns a dictionary with version information.
+    """
+    version_info = {
+        'commit_hash': 'Unknown',
+        'commit_short': 'Unknown', 
+        'branch': 'Unknown',
+        'commit_date': 'Unknown',
+        'commit_message': 'Unknown',
+        'is_dirty': False,
+        'last_tag': 'Unknown'
+    }
+    
+    try:
+        # Check if we're in a git repository
+        result = subprocess.run(['git', 'rev-parse', '--is-inside-work-tree'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        if result.returncode != 0:
+            logger.warning("Not in a git repository")
+            return version_info
+            
+        # Get commit hash (full)
+        result = subprocess.run(['git', 'rev-parse', 'HEAD'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        if result.returncode == 0:
+            version_info['commit_hash'] = result.stdout.strip()
+            version_info['commit_short'] = result.stdout.strip()[:7]
+            
+        # Get branch name
+        result = subprocess.run(['git', 'branch', '--show-current'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        if result.returncode == 0 and result.stdout.strip():
+            version_info['branch'] = result.stdout.strip()
+        else:
+            # Fallback for detached HEAD (common in CI/CD)
+            result = subprocess.run(['git', 'describe', '--all', '--exact-match', 'HEAD'], 
+                                  capture_output=True, text=True, cwd=os.path.dirname(__file__))
+            if result.returncode == 0:
+                version_info['branch'] = result.stdout.strip().replace('heads/', '')
+                
+        # Get commit date
+        result = subprocess.run(['git', 'log', '-1', '--format=%ci', 'HEAD'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        if result.returncode == 0:
+            version_info['commit_date'] = result.stdout.strip()
+            
+        # Get commit message (first line only)
+        result = subprocess.run(['git', 'log', '-1', '--format=%s', 'HEAD'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        if result.returncode == 0:
+            version_info['commit_message'] = result.stdout.strip()[:100]  # Limit length
+            
+        # Check if working directory is dirty
+        result = subprocess.run(['git', 'diff-index', '--quiet', 'HEAD'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        version_info['is_dirty'] = result.returncode != 0
+        
+        # Get last tag
+        result = subprocess.run(['git', 'describe', '--tags', '--abbrev=0'], 
+                              capture_output=True, text=True, cwd=os.path.dirname(__file__))
+        if result.returncode == 0:
+            version_info['last_tag'] = result.stdout.strip()
+            
+    except FileNotFoundError:
+        logger.warning("Git command not found")
+    except Exception as e:
+        logger.warning(f"Error getting git info: {e}")
+        
+    return version_info
+
+def format_version_message():
+    """
+    Format version information into a user-friendly message.
+    """
+    info = get_git_info()
+    
+    # Format commit date nicely
+    commit_date_formatted = "Unknown"
+    if info['commit_date'] != 'Unknown':
+        try:
+            # Parse the git date format: "2025-01-05 14:30:45 +0100"
+            dt = datetime.strptime(info['commit_date'][:19], '%Y-%m-%d %H:%M:%S')
+            commit_date_formatted = dt.strftime('%Y-%m-%d %H:%M')
+        except:
+            commit_date_formatted = info['commit_date']
+    
+    # Build message parts
+    message_parts = [
+        f"<b>🤖 Bot Version Info</b>",
+        "",
+        f"<b>Commit:</b> <code>{info['commit_short']}</code>",
+        f"<b>Branch:</b> <code>{info['branch']}</code>",
+        f"<b>Date:</b> <code>{commit_date_formatted}</code>",
+    ]
+    
+    if info['last_tag'] != 'Unknown':
+        message_parts.append(f"<b>Tag:</b> <code>{info['last_tag']}</code>")
+        
+    if info['commit_message'] != 'Unknown':
+        message_parts.append(f"<b>Last commit:</b> <i>{info['commit_message']}</i>")
+        
+    if info['is_dirty']:
+        message_parts.append("")
+        message_parts.append("⚠️ <i>Working directory has uncommitted changes</i>")
+        
+    return "\n".join(message_parts)

--- a/utils/version_command.py
+++ b/utils/version_command.py
@@ -1,0 +1,37 @@
+# utils/version_command.py
+from utils.version import format_version_message
+from telegram_helpers.delete_message import add_delete_button
+from utils.session_avatar import PA
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def version_command(update, context):
+    """
+    Handle /version command - shows Git version information.
+    """
+    try:
+        # Get version information
+        version_message = format_version_message()
+        
+        # Add PA emoji to the message
+        version_message += f"\n\n{PA}"
+        
+        # Send version information
+        version_response = await update.message.reply_text(
+            version_message,
+            parse_mode="HTML"
+        )
+        
+        # Add delete button
+        await add_delete_button(update, context, version_response.message_id)
+        
+        logger.info("Version command executed successfully")
+        
+    except Exception as e:
+        error_message = f"Error getting version info: {e}"
+        logger.error(error_message)
+        await update.message.reply_text(
+            f"❌ {error_message} {PA}",
+            parse_mode="HTML"
+        )


### PR DESCRIPTION
## 🚀 Features Added
- **New `/version` command** that shows Git version information
- Displays commit hash, branch, date, last tag, and commit message  
- Helps track which version is running in prod vs test environments

## 🐛 Bug Fixes
- **Fixed temperature parameter error** in LLM configuration
- Set explicit `temperature=1` for all ChatOpenAI models to avoid "Unsupported value" errors

## 📁 Files Changed
- `utils/version.py` - Core Git information utility functions
- `utils/version_command.py` - Telegram command handler  
- `main.py` - Added version command registration
- `LLMs/config.py` - Fixed temperature parameters

## 🧪 Testing
- ✅ `/version` command tested and working
- ✅ Temperature error resolved
- ✅ Bot starts successfully without errors

This will help distinguish between test and production bot versions when deploying!